### PR TITLE
Quelques améliorations mineures au graphique sur la ponctualité

### DIFF
--- a/src/app/components/graphs/BusPunctualityChart.tsx
+++ b/src/app/components/graphs/BusPunctualityChart.tsx
@@ -2,20 +2,21 @@ import { CardContent, CardHeader } from "@mui/material";
 import { ChartjsOptions } from "@/types/ChartjsOptions"
 import * as colorUtils from "@/utils/color-utils";
 import { ScatterPlot } from "./templates/ScatterPlot";
-import { integerDivision } from "@/utils/math-utils";
+import { integerDivision, mean, median } from "@/utils/math-utils";
 
 export const BusPunctualityChart = ({busData}) => {
 
-    const data = busData.map((bus, i) => ({x:i+1, y:bus.punctuality}));
-    const colors = generateColors(busData.map((bus) => bus.punctuality))
+    const scatterFormatData = busData.map((bus, i) => ({x:i+1, y:integerDivision(bus.punctuality, 60)}));
+    const offsets = busData.map((bus) => bus.punctuality);
+    const colors = generateColors(offsets);
 
     const chartOptions : ChartjsOptions = {
-        labels:["Test"],
-        data:data,
+        labels:[],
+        data:scatterFormatData,
         colors:colors,
-        xAxisTitle:"",
-        yAxisTitle:"Décalage avec le temps d'arrivé prévu (secondes)",
-        yAxisBeginAt0:false,
+        xTitle:"",
+        yTitle:"Décalage avec le temps d'arrivé prévu (minutes)",
+        yBeginAt0:false,
         tooltipLabelCallBack:(context) => offsetToString(context.raw.y)
     }
 
@@ -23,13 +24,17 @@ export const BusPunctualityChart = ({busData}) => {
         <>
             <CardHeader title="Ponctualité des autobus"></CardHeader>
             <CardContent id="punctuality-chart" className="w-full h-full">
-                <ScatterPlot chartOptions={chartOptions}/>
+                <div className="flex flex-col w-full h-5/6">
+                    <ScatterPlot chartOptions={chartOptions}/>
+                    <span><strong>Moyenne: </strong>{offsetToString(mean(offsets).toFixed(1))}</span>
+                    <span><strong>Médiane: </strong>{offsetToString(median(offsets).toFixed(1))}</span>
+                </div>
             </CardContent>
         </>
     )
 }
 
-const timeDivisor : number = 1000;
+const timeDivisor : number = 20;
 
 const toColorIndex = (value) => integerDivision(Math.abs(value), timeDivisor);
 
@@ -43,16 +48,14 @@ const generateColors = (data) => {
     return data.map(offset => offset <= 0 ? greens[toColorIndex(offset)] : reds[toColorIndex(offset)]);
 }
 
-const timeUnitToString = (absOffset) => {
-    const numericValue = absOffset < 60 ? absOffset : integerDivision(absOffset, 60);
-    const timeUnit = absOffset < 60 ? " seconde" : " minute";
-
-    return numericValue + (numericValue > 1 ? timeUnit + "s" : timeUnit);
-}
-
 const offsetToString = (offset) => {
-    const timeUnit = timeUnitToString(Math.abs(offset))
+    if (offset === 0){
+        return "Arrivé à temps"
+    }
+
+    const absOffset = Math.abs(offset);
+    const timeUnit = ` ${absOffset > 1 ? "minutes" : "minute"}`
     const timeQualifier = ` ${offset < 0 ? "d'avance" : "de retard"}`
 
-    return timeUnit + timeQualifier;
+    return absOffset + timeUnit + timeQualifier;
 }

--- a/src/app/components/graphs/OccupancyChart.tsx
+++ b/src/app/components/graphs/OccupancyChart.tsx
@@ -14,9 +14,9 @@ export const OccupancyChart = ({busData}) => {
         labels:["Vide", "Faible", "Moyen", "Élevé", "Plein"],
         data:busCount,
         colors:getColorsFromScale(occupancyCount, LightRed, EtsRed),
-        xAxisTitle:"Niveau d'occupation",
-        yAxisTitle:"Nombre d'autobus",
-        yAxisBeginAt0:true,
+        xTitle:"Niveau d'occupation",
+        yTitle:"Nombre d'autobus",
+        yBeginAt0:true,
         tooltipLabelCallBack:(context) => `${context.raw} autobus`
     }
 

--- a/src/app/components/graphs/templates/BarChart.tsx
+++ b/src/app/components/graphs/templates/BarChart.tsx
@@ -20,17 +20,17 @@ export const BarChart = ({chartOptions}) => {
                 },
                 title: {
                     display: true,
-                    text: chartOptions.xAxisTitle
+                    text: chartOptions.xTitle
                 }
             },
             y: {
-                beginAtZero:chartOptions.yAxisBeginAt0,
+                beginAtZero:chartOptions.yBeginAt0,
                 ticks: { 
                     precision: 0 
                 },
                 title:{
                     display: true,
-                    text: chartOptions.yAxisTitle
+                    text: chartOptions.yTitle
                 },
                 type: "linear"
             }

--- a/src/app/components/graphs/templates/ScatterPlot.tsx
+++ b/src/app/components/graphs/templates/ScatterPlot.tsx
@@ -27,13 +27,13 @@ export const ScatterPlot = ({chartOptions}) => {
                 },
             },
             y: {
-                beginAtZero:chartOptions.yAxisBeginAt0,
+                beginAtZero:chartOptions.yBeginAt0,
                 ticks: { 
                     precision: 0 
                 },
                 title:{
                     display: true,
-                    text: chartOptions.yAxisTitle
+                    text: chartOptions.yTitle
                 }
             }
         },
@@ -94,7 +94,7 @@ export const ScatterPlot = ({chartOptions}) => {
 
     return (
         <div className="h-full w-full flex justify-center items-center">
-            <div ref={containerRef} className="w-4/5 h-4/5 flex justify-center items-center">
+            <div ref={containerRef} className="w-4/5 h-5/6 flex justify-center items-center">
                 {/* The direct container of the canvas determines its sizing. */}
                 <canvas ref={canvasRef} className="mr-10"></canvas>
             </div>

--- a/src/types/ChartjsOptions.ts
+++ b/src/types/ChartjsOptions.ts
@@ -2,8 +2,8 @@ export type ChartjsOptions = {
     labels:string[];
     data:number[];
     colors:string[];
-    xAxisTitle:string;
-    yAxisTitle:string;
-    yAxisBeginAt0:boolean;
+    xTitle:string;
+    yTitle:string;
+    yBeginAt0:boolean;
     tooltipLabelCallBack?;
 }


### PR DESCRIPTION
Juste quelques améliorations mineures selon les commentaires des profs. Ça va potentiellementt changer pour un histogramme d'ici une dizaine de jour. 

- Changer le scaling pour être en minutes
- Ajouter la moyenne et la médiane (plain text pour l'instant)
- Tooltip indique si le bus est arrivé à l'heure (moins d'une minute de diff)

![image](https://github.com/Monitoring-Mtl/Frontend/assets/38772486/62848a05-fa30-4b5e-91fb-1b43bca752dc)
