### PR TITLE
Quelques améliorations visuelles pour la carte

### DIFF
--- a/src/app/components/map/StmMap.tsx
+++ b/src/app/components/map/StmMap.tsx
@@ -142,10 +142,8 @@ const resetStopStyles = (stopsLayer:VectorLayer<VectorSource> | null) => {
 const etsCoordinates = fromLonLat([-73.56198339521531, 45.49501768328183]);
 
 const getMapCenter = (routeShape:RouteShape | undefined) => {
-    let center = etsCoordinates;
-
     if (!routeShape || routeShape.coordinates.length < 1){
-        return center;
+        return etsCoordinates;
     }
 
     return routeShape.coordinates[integerDivision(routeShape.coordinates.length, 2)];

--- a/src/app/components/map/StmMap.tsx
+++ b/src/app/components/map/StmMap.tsx
@@ -4,15 +4,14 @@ import { Feature, MapBrowserEvent, Overlay } from "ol";
 import { LineString, Point } from "ol/geom";
 import { Vector as VectorLayer } from "ol/layer";
 import { Vector as VectorSource } from "ol/source";
-import { Style, Stroke } from "ol/style";
+import { Circle, Fill, Style, Stroke } from "ol/style";
 import { RouteShape} from "@/types/RouteShape";
 import { Stop } from "@/types/Stop";
 import { MapOptions } from "@/types/MapOptions";
 import { Map as OlMap } from "openlayers";
 import { Map } from "./Map";
 import { integerDivision } from "@/utils/math-utils";
-
-const montrealCoordinates = fromLonLat([-73.56198339521531, 45.49501768328183]);
+import { StmBusBlue } from "@/utils/color-utils";
 
 interface IStmMap {
     routeShape?: RouteShape;
@@ -21,7 +20,7 @@ interface IStmMap {
 
 export const StmMap = memo(({ routeShape, stops }: IStmMap) => {
 
-    let routeLayer;
+    let routeLayer:VectorLayer<VectorSource> | null = null;
     if (routeShape) {
         routeLayer = new VectorLayer({
             source: new VectorSource({
@@ -33,16 +32,16 @@ export const StmMap = memo(({ routeShape, stops }: IStmMap) => {
             }),
             style: new Style({
                 stroke: new Stroke({
-                    color: "#0000ff",
-                    width: 1,
+                    color: StmBusBlue,
+                    width: 3,
                 }),
             }),
         });
     }
 
-    let center = montrealCoordinates;
+    let center = getMapCenter(routeShape);
 
-    let stopsLayer;
+    let stopsLayer:VectorLayer<VectorSource> | null = null;
     if (stops) {
         let features: Feature[] = [];
 
@@ -68,37 +67,88 @@ export const StmMap = memo(({ routeShape, stops }: IStmMap) => {
             source: new VectorSource({
                 features: features,
             }),
+            style: stopStyle
         });
-
-        const centralStop = stops[integerDivision(stops.length, 2)];
-        if (centralStop){
-            center = centralStop.coordinates;
-        }
     }
 
     const pointermoveCallback = (event:MapBrowserEvent<any>, map:OlMap, overlay:Overlay) => {
         let feature = map.forEachFeatureAtPixel(event.pixel as ol.Pixel, (feature) => feature );
         const properties = feature?.getProperties();
+
         if (feature !== undefined && properties.isStop) {
             overlay.setPosition(event.coordinate);
             const overlayRef = overlay.getElement();
+
             if (overlayRef){
                 overlayRef.textContent = `Arrêt ${properties.name}`
             }
+
+            resetStopStyles(stopsLayer);
+
+            if (feature instanceof Feature){
+                feature.setStyle(hoverStopStyle);
+            }
         } else {
             overlay.setPosition(undefined);
+            resetStopStyles(stopsLayer);
         }
     }
 
     const mapOptions: MapOptions = {
         id: "stm-map",
         center: center,
-        zoom: 12,
+        zoom: 13,
         layers: [routeLayer, stopsLayer],
-        pointermoveCallback:pointermoveCallback
+        pointermoveCallback:pointermoveCallback,
     };
 
     return <Map mapOptions={mapOptions} />;
 });
+
+const stopStyle = new Style({
+    image: new Circle({
+        radius: 5,
+        fill: new Fill({
+          color: "white"
+        }),
+        stroke: new Stroke({
+            color: StmBusBlue,
+            width: 2,
+        }),
+    })
+});
+
+const hoverStopStyle = new Style({
+    image: new Circle({
+        radius: 6,
+        fill: new Fill({
+          color: "white"
+        }),
+        stroke: new Stroke({
+            color: StmBusBlue,
+            width: 2,
+        }),
+    })
+});
+
+const resetStopStyles = (stopsLayer:VectorLayer<VectorSource> | null) => {
+    stopsLayer?.getSource()?.getFeatures()?.forEach((feature => {
+        if (feature.getProperties().isStop && feature instanceof Feature){
+            feature.setStyle(stopStyle);
+        }
+    }));
+}
+
+const etsCoordinates = fromLonLat([-73.56198339521531, 45.49501768328183]);
+
+const getMapCenter = (routeShape:RouteShape | undefined) => {
+    let center = etsCoordinates;
+
+    if (!routeShape || routeShape.coordinates.length < 1){
+        return center;
+    }
+
+    return routeShape.coordinates[integerDivision(routeShape.coordinates.length, 2)];
+}
 
 StmMap.displayName = "StmMap";

--- a/src/utils/color-utils.ts
+++ b/src/utils/color-utils.ts
@@ -5,6 +5,7 @@ export const EtsRed : string = "#ef3e45";
 export const EtsCharcoal : string = "#414042";
 export const LightGreen : string = "#b1f8b2";
 export const Green : string = "#3eef45";
+export const StmBusBlue : string = "#0085ca";
 
 export const getColorsFromScale = (nbOfColors:number, fromColor:string, toColor:string) => {
     const colorScale = d3.scaleSequential(d3.interpolate(fromColor, toColor));


### PR DESCRIPTION
### 🛠  Why are these changes being made? / Quel est l'objectif du changement?

What's the context for the changes? Is there an issue linked with this merge request?
Pourquoi faire ce changement? Est-ce qu'il y a une issue liée à la merge request?

La ligne et les arrêts avait encore le style par défaut.

### 🧠 How are these changes made? / Comment as-tu implémenté ce changement?

How did you fix the issue? Were there any trade-offs you had to consider?
Comment as-tu résolu le problème? Y-a-t'il eu des concessions à faire?

La ligne et les arrêts utilisent le bleu de la STM. La ligne est plus large. La couleur des arrêt a changé. Il y a un effet d'aggrissement des arrêts on hover. 

### 📸 Screenshots (optional)

If you made UI changes, what are the before and after?
Si tu as fait un changement à l'interface graphique, quel est le avant et le après?

Avant:
![image](https://github.com/Monitoring-Mtl/Frontend/assets/38772486/11376f4c-7b9a-4e8c-b1cf-32fe77051294)

Après:
![image](https://github.com/Monitoring-Mtl/Frontend/assets/38772486/e2f66023-3c86-477c-b659-e85da0fcac6b)

La couleur est basée sur un bleu utilisé par la STM:
![image](https://github.com/Monitoring-Mtl/Frontend/assets/38772486/d6d31faf-da53-44f1-a220-8ced131e8e8e)

Le style des arrêts se base aussi sur le visuel du site de la STM:
![image](https://github.com/Monitoring-Mtl/Frontend/assets/38772486/be543c85-8410-41c0-8606-b495557dd69b)


L'arrêt aggrandit légèrement on hover:
![image](https://github.com/Monitoring-Mtl/Frontend/assets/38772486/81c6f704-baf8-4939-a1a3-3de743c33d81)
![image](https://github.com/Monitoring-Mtl/Frontend/assets/38772486/b3d01a15-c6a9-4f85-a73b-2dbff9a5842d)

La carte se centre également sur le milieu de la ligne lorsqu'on change de ligne/direction.
